### PR TITLE
Future-proof LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Adam Hjalmarsson, Joseph Hughes, Linnéa Ivansson, Johan Lindström, Oscar Lönnqvist, Maximilian Vorbrodt, Annie Wång
+Copyright (c) 2021 Adam Hjalmarsson, Joseph Hughes, Linnéa Ivansson, Johan Lindström, Oscar Lönnqvist, Maximilian Vorbrodt, Annie Wång and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add "and contributors" to copyright holders.

The project is set to be public in the future and may contain commits be people that are not the primary authors. Those contributions do not belong to the primary copyright holders and this should be explicit in the license.

See https://opensource.stackexchange.com/a/5511